### PR TITLE
PRODENG-2501 Remove security group id injection 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,49 +28,52 @@ module "common" {
 }
 
 module "masters" {
-  source                = "./modules/master"
-  master_count          = var.master_count
-  vpc_id                = module.vpc.id
-  cluster_name          = local.cluster_name
-  subnet_ids            = module.vpc.public_subnet_ids
-  security_group_id     = module.common.security_group_id
-  master_type           = var.master_type
-  master_volume_size    = var.master_volume_size
-  image_id              = module.common.image_id
-  kube_cluster_tag      = module.common.kube_cluster_tag
-  ssh_key               = local.cluster_name
-  instance_profile_name = module.common.instance_profile_name
+  source                      = "./modules/master"
+  master_count                = var.master_count
+  vpc_id                      = module.vpc.id
+  cluster_name                = local.cluster_name
+  subnet_ids                  = module.vpc.public_subnet_ids
+  security_group_id           = module.common.security_group_id
+  master_type                 = var.master_type
+  master_volume_size          = var.master_volume_size
+  image_id                    = module.common.image_id
+  kube_cluster_tag            = module.common.kube_cluster_tag
+  ssh_key                     = local.cluster_name
+  instance_profile_name       = module.common.instance_profile_name
+  additional_ingress_sg_rules = var.additional_master_ingress_sg_rules
 }
 
 module "msrs" {
-  count                 = var.msr_count >= 1 ? 1 : 0
-  source                = "./modules/msr"
-  msr_count             = var.msr_count
-  vpc_id                = module.vpc.id
-  cluster_name          = local.cluster_name
-  subnet_ids            = module.vpc.public_subnet_ids
-  security_group_id     = module.common.security_group_id
-  image_id              = module.common.image_id
-  msr_type              = var.msr_type
-  msr_volume_size       = var.msr_volume_size
-  kube_cluster_tag      = module.common.kube_cluster_tag
-  ssh_key               = local.cluster_name
-  instance_profile_name = module.common.instance_profile_name
+  count                       = var.msr_count >= 1 ? 1 : 0
+  source                      = "./modules/msr"
+  msr_count                   = var.msr_count
+  vpc_id                      = module.vpc.id
+  cluster_name                = local.cluster_name
+  subnet_ids                  = module.vpc.public_subnet_ids
+  security_group_id           = module.common.security_group_id
+  image_id                    = module.common.image_id
+  msr_type                    = var.msr_type
+  msr_volume_size             = var.msr_volume_size
+  kube_cluster_tag            = module.common.kube_cluster_tag
+  ssh_key                     = local.cluster_name
+  instance_profile_name       = module.common.instance_profile_name
+  additional_ingress_sg_rules = var.additional_msr_ingress_sg_rules
 }
 
 module "workers" {
-  source                = "./modules/worker"
-  worker_count          = var.worker_count
-  vpc_id                = module.vpc.id
-  cluster_name          = local.cluster_name
-  subnet_ids            = module.vpc.public_subnet_ids
-  security_group_id     = module.common.security_group_id
-  image_id              = module.common.image_id
-  worker_type           = var.worker_type
-  worker_volume_size    = var.worker_volume_size
-  kube_cluster_tag      = module.common.kube_cluster_tag
-  ssh_key               = local.cluster_name
-  instance_profile_name = module.common.instance_profile_name
+  source                      = "./modules/worker"
+  worker_count                = var.worker_count
+  vpc_id                      = module.vpc.id
+  cluster_name                = local.cluster_name
+  subnet_ids                  = module.vpc.public_subnet_ids
+  security_group_id           = module.common.security_group_id
+  image_id                    = module.common.image_id
+  worker_type                 = var.worker_type
+  worker_volume_size          = var.worker_volume_size
+  kube_cluster_tag            = module.common.kube_cluster_tag
+  ssh_key                     = local.cluster_name
+  instance_profile_name       = module.common.instance_profile_name
+  additional_ingress_sg_rules = var.additional_worker_ingress_sg_rules
 }
 
 module "windows_workers" {
@@ -86,6 +89,7 @@ module "windows_workers" {
   kube_cluster_tag               = module.common.kube_cluster_tag
   instance_profile_name          = module.common.instance_profile_name
   windows_administrator_password = var.windows_administrator_password
+  additional_ingress_sg_rules    = var.additional_windows_worker_ingress_sg_rules
 }
 
 locals {

--- a/modules/master/main.tf
+++ b/modules/master/main.tf
@@ -23,6 +23,21 @@ resource "aws_security_group" "master" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+  dynamic "ingress" {
+    for_each = var.additional_ingress_sg_rules
+    content {
+      from_port        = ingress.value["from_port"]
+      to_port          = ingress.value["to_port"]
+      protocol         = ingress.value["protocol"]
+      cidr_blocks      = ingress.value["cidr_blocks"]
+      ipv6_cidr_blocks = ingress.value["ipv6_cidr_blocks"]
+      prefix_list_ids  = ingress.value["prefix_list_ids"]
+      self             = ingress.value["self"]
+      description      = ingress.value["description"]
+    }
+  }
+
   tags = {
     "kubernetes.io/cluster/${var.cluster_name}" = "owned"
   }

--- a/modules/master/variables.tf
+++ b/modules/master/variables.tf
@@ -29,3 +29,18 @@ variable "master_type" {
 variable "master_volume_size" {
   default = 100
 }
+
+variable "additional_ingress_sg_rules" {
+  description = "Additional security group ingress rules to attach to the master nodes"
+  type = list(object({
+    from_port        = string
+    to_port          = string
+    protocol         = string
+    cidr_blocks      = optional(list(string))
+    ipv6_cidr_blocks = optional(list(string))
+    prefix_list_ids  = optional(list(string))
+    self             = optional(bool)
+    description      = optional(string)
+  }))
+  default = []
+}

--- a/modules/msr/main.tf
+++ b/modules/msr/main.tf
@@ -10,6 +10,20 @@ resource "aws_security_group" "msr" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  dynamic "ingress" {
+    for_each = var.additional_ingress_sg_rules
+    content {
+      from_port        = ingress.value["from_port"]
+      to_port          = ingress.value["to_port"]
+      protocol         = ingress.value["protocol"]
+      cidr_blocks      = ingress.value["cidr_blocks"]
+      ipv6_cidr_blocks = ingress.value["ipv6_cidr_blocks"]
+      prefix_list_ids  = ingress.value["prefix_list_ids"]
+      self             = ingress.value["self"]
+      description      = ingress.value["description"]
+    }
+  }
+
 }
 
 locals {

--- a/modules/msr/variables.tf
+++ b/modules/msr/variables.tf
@@ -31,3 +31,18 @@ variable "msr_type" {
 variable "msr_volume_size" {
   default = 100
 }
+
+variable "additional_ingress_sg_rules" {
+  description = "Additional security group ingress rules to attach to the msr nodes"
+  type = list(object({
+    from_port        = string
+    to_port          = string
+    protocol         = string
+    cidr_blocks      = optional(list(string))
+    ipv6_cidr_blocks = optional(list(string))
+    prefix_list_ids  = optional(list(string))
+    self             = optional(bool)
+    description      = optional(string)
+  }))
+  default = []
+}

--- a/modules/windows_worker/main.tf
+++ b/modules/windows_worker/main.tf
@@ -9,6 +9,20 @@ resource "aws_security_group" "worker" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+  dynamic "ingress" {
+    for_each = var.additional_ingress_sg_rules
+    content {
+      from_port        = ingress.value["from_port"]
+      to_port          = ingress.value["to_port"]
+      protocol         = ingress.value["protocol"]
+      cidr_blocks      = ingress.value["cidr_blocks"]
+      ipv6_cidr_blocks = ingress.value["ipv6_cidr_blocks"]
+      prefix_list_ids  = ingress.value["prefix_list_ids"]
+      self             = ingress.value["self"]
+      description      = ingress.value["description"]
+    }
+  }
 }
 
 locals {

--- a/modules/windows_worker/variables.tf
+++ b/modules/windows_worker/variables.tf
@@ -28,3 +28,19 @@ variable "worker_volume_size" {
 
 variable "windows_administrator_password" {
 }
+
+variable "additional_ingress_sg_rules" {
+  description = "Additional security group ingress rules to attach to the windows worker nodes"
+  type = list(object({
+    from_port        = string
+    to_port          = string
+    protocol         = string
+    cidr_blocks      = optional(list(string))
+    ipv6_cidr_blocks = optional(list(string))
+    prefix_list_ids  = optional(list(string))
+    self             = optional(bool)
+    description      = optional(string)
+  }))
+  default = []
+}
+

--- a/modules/worker/main.tf
+++ b/modules/worker/main.tf
@@ -5,6 +5,20 @@ resource "aws_security_group" "worker" {
   tags = {
     "kubernetes.io/cluster/${var.cluster_name}" = "owned"
   }
+
+  dynamic "ingress" {
+    for_each = var.additional_ingress_sg_rules
+    content {
+      from_port        = ingress.value["from_port"]
+      to_port          = ingress.value["to_port"]
+      protocol         = ingress.value["protocol"]
+      cidr_blocks      = ingress.value["cidr_blocks"]
+      ipv6_cidr_blocks = ingress.value["ipv6_cidr_blocks"]
+      prefix_list_ids  = ingress.value["prefix_list_ids"]
+      self             = ingress.value["self"]
+      description      = ingress.value["description"]
+    }
+  }
 }
 
 locals {

--- a/modules/worker/variables.tf
+++ b/modules/worker/variables.tf
@@ -29,3 +29,18 @@ variable "worker_type" {
 variable "worker_volume_size" {
   default = 100
 }
+
+variable "additional_ingress_sg_rules" {
+  description = "Additional security group ingress rules to attach to the worker nodes"
+  type = list(object({
+    from_port        = string
+    to_port          = string
+    protocol         = string
+    cidr_blocks      = optional(list(string))
+    ipv6_cidr_blocks = optional(list(string))
+    prefix_list_ids  = optional(list(string))
+    self             = optional(bool)
+    description      = optional(string)
+  }))
+  default = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -157,3 +157,63 @@ variable "ssh_key_file_path" {
   default     = ""
   description = "If non-empty, use this path/filename as the ssh key file instead of generating automatically."
 }
+
+variable "additional_master_ingress_sg_rules" {
+  description = "Additional security group rules to attach to the master nodes"
+  type = list(object({
+    from_port        = string
+    to_port          = string
+    protocol         = string
+    cidr_blocks      = optional(list(string))
+    ipv6_cidr_blocks = optional(list(string))
+    prefix_list_ids  = optional(list(string))
+    self             = optional(bool)
+    description      = optional(string)
+  }))
+  default = []
+}
+
+variable "additional_worker_ingress_sg_rules" {
+  description = "Additional security group rules to attach to the worker nodes"
+  type = list(object({
+    from_port        = string
+    to_port          = string
+    protocol         = string
+    cidr_blocks      = optional(list(string))
+    ipv6_cidr_blocks = optional(list(string))
+    prefix_list_ids  = optional(list(string))
+    self             = optional(bool)
+    description      = optional(string)
+  }))
+  default = []
+}
+
+variable "additional_windows_worker_ingress_sg_rules" {
+  description = "Additional security group rules to attach to the windows worker nodes"
+  type = list(object({
+    from_port        = string
+    to_port          = string
+    protocol         = string
+    cidr_blocks      = optional(list(string))
+    ipv6_cidr_blocks = optional(list(string))
+    prefix_list_ids  = optional(list(string))
+    self             = optional(bool)
+    description      = optional(string)
+  }))
+  default = []
+}
+
+variable "additional_msr_ingress_sg_rules" {
+  description = "Additional security group rules to attach to the MSR nodes"
+  type = list(object({
+    from_port        = string
+    to_port          = string
+    protocol         = string
+    cidr_blocks      = optional(list(string))
+    ipv6_cidr_blocks = optional(list(string))
+    prefix_list_ids  = optional(list(string))
+    self             = optional(bool)
+    description      = optional(string)
+  }))
+  default = []
+}


### PR DESCRIPTION
- Replaced the security group id injection with injecting ingress rules since security groups cannot be created without vpc_id that gets created within the module
- If needed we can introduce new variables for injecting egress rules as well
- Tested and verified if the ingress rules get attached to security groups 