### PR TITLE
Revert "PRODENG-2501 Allowed the creation of custom Security Group rules"

### DIFF
--- a/modules/windows_worker/main.tf
+++ b/modules/windows_worker/main.tf
@@ -19,8 +19,8 @@ resource "aws_instance" "mke_worker" {
   count = var.worker_count
 
   tags = tomap({
-    "Name"                 = "${var.cluster_name}-win-worker-${count.index + 1}",
-    "Role"                 = "worker",
+    "Name" = "${var.cluster_name}-win-worker-${count.index + 1}",
+    "Role" = "worker",
     (var.kube_cluster_tag) = "shared"
   })
 
@@ -94,13 +94,12 @@ EOF
   }
 
   connection {
-    type     = "winrm"
-    user     = "Administrator"
-    password = var.windows_administrator_password
-    timeout  = "10m"
-    https    = "true"
+    type = "winrm"
+    user = "Administrator"
+    password = var.administrator_password
+    timeout = "10m"
+    https = "true"
     insecure = "true"
-    port     = 5986
-    host     = self.public_ip
+    port=5986
   }
 }


### PR DESCRIPTION
Reverts terraform-mirantis-modules/terraform-mirantis-launchpad-aws#7

The sg input doesn't make sense, as SGs are contained in the VPC, and here the VPC is created in the module, so you can't create a valid SG before running the module.